### PR TITLE
docker compose repeated anchors fix

### DIFF
--- a/development/docker-compose/docker-compose.yaml
+++ b/development/docker-compose/docker-compose.yaml
@@ -158,9 +158,7 @@ services:
     ports:
       - "8040:8080"
     environment:
-      <<: *common-variables
-      <<: *message-broker-variables
-      <<: *database-variables
+      <<: [*common-variables, *message-broker-variables, *database-variables]
       spring.datasource.url: jdbc:mysql://mysql:3306/access-control?useSSL=false&allowPublicKeyRetrieval=true&cacheServerConfiguration=true&createDatabaseIfNotExist=true
     volumes:
       - ./scripts:/tmp/h
@@ -180,9 +178,7 @@ services:
     ports:
       - "8050:8080"
     environment:
-      <<: *common-variables
-      <<: *message-broker-variables
-      <<: *database-variables
+      <<: [*common-variables, *message-broker-variables, *database-variables]
       spring.datasource.url: jdbc:mysql://mysql:3306/arrangement-manager?useSSL=false&allowPublicKeyRetrieval=true&cacheServerConfiguration=true&createDatabaseIfNotExist=true
     volumes:
       - ./scripts:/tmp/h
@@ -202,9 +198,7 @@ services:
     ports:
       - "8060:8080"
     environment:
-      <<: *common-variables
-      <<: *message-broker-variables
-      <<: *database-variables
+      <<: [*common-variables, *message-broker-variables, *database-variables]
       spring.datasource.url: jdbc:mysql://mysql:3306/user-manager?useSSL=false&allowPublicKeyRetrieval=true&cacheServerConfiguration=true&createDatabaseIfNotExist=true
       backbase.users.identity-endpoints-enabled: true
       backbase.users.identity-integration-enabled: true


### PR DESCRIPTION
From reported [bug](https://github.com/docker/compose/issues/10411)
```
goyaml/v3 does not support repeated anchors (due to internal storage using << as key during parsing) but allows use of multi-values in anchors
``` 

While this change is from docker-compose 2.17+ cli, this also works with older version of docker-compose. 

I check with my older version of 2.5 and it works. Downside is that although yaml supports this IntelliJ linters shows an error
<img width="728" alt="image" src="https://user-images.githubusercontent.com/950278/231877604-748873fb-c868-4df9-b6d7-ddedd3ee2a60.png">
Please give it a try with your existing docker-compose cli version. 

