### PR TITLE
Fix link to service creation guidelines in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Set up a Docker local environment on your laptop by running these commands in th
 
 **NB:** EMU account required to access (https://github.com/baas-devops-reference)
 
-To create custom services in the Backbase ecosystem, Backbase recommends using [ModelBank templates](https://github.com/baas-devops-reference?q=template&type=all&sort=). If you don't have an EMU account, you can find detailed instructions on creating a service using the service SDK (core-service-archetype) in the [create a service guidelines](https://backbase.io/developers/documentation/backend-devkit/latest/development/create-a-service/).
+To create custom services in the Backbase ecosystem, Backbase recommends using [ModelBank templates](https://github.com/baas-devops-reference?q=template&type=all&sort=). If you don't have an EMU account, you can find detailed instructions on creating a service using the service SDK (core-service-archetype) in the [create a service guidelines](https://backbase.io/documentation/backend-devkit/latest/creating-services/create-ssdk-service).
 
 Use these guidelines to develop your own service, and use the Backbase local environment to test and run your code. 
 


### PR DESCRIPTION
Updated the link for creating a service using the service SDK.